### PR TITLE
Extract hosts/pods/containers/services assets

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,5 @@
 export const LOGS_INDICES = 'logs-*,filebeat-*';
-export const APM_INDICES = 'traces-*,apm*,metrics-apm*';
+export const APM_INDICES = 'traces-*,apm*,metrics-apm*,logs-apm*';
 export const METRICS_INDICES = 'metrics-*,metricbeat-*';
 
 export const REMOTE_LOGS_INDICES = 'remote_cluster:logs-*,remote_cluster:filebeat-*';

--- a/constants.ts
+++ b/constants.ts
@@ -1,8 +1,10 @@
 export const LOGS_INDICES = 'logs-*,filebeat-*';
 export const APM_INDICES = 'traces-*,apm*,metrics-apm*';
+export const METRICS_INDICES = 'metrics-*,metricbeat-*';
 
 export const REMOTE_LOGS_INDICES = 'remote_cluster:logs-*,remote_cluster:filebeat-*';
 export const REMOTE_APM_INDICES = 'remote_cluster:traces-*,remote_cluster:apm*,remote_cluster:metrics-apm*';
+export const REMOTE_METRICS_INDICES = 'remote_cluster:metrics-*,remote_cluster:metricbeat-*';
 
 export function getLogsIndices() {
   if (process.env.ES_IS_CCS === "true") {
@@ -17,5 +19,13 @@ export function getApmIndices() {
     return REMOTE_APM_INDICES;
   } else {
     return APM_INDICES;
+  }
+}
+
+export function getMetricsIndices() {
+  if (process.env.ES_IS_CCS === "true") {
+    return REMOTE_METRICS_INDICES;
+  } else {
+    return METRICS_INDICES;
   }
 }

--- a/lib/assets_index_template.ts
+++ b/lib/assets_index_template.ts
@@ -4,6 +4,7 @@ export const assetsIndexTemplateConfig: IndicesPutIndexTemplateRequest = {
   name: 'assets',
   index_patterns: ['assets*'],
   priority: 100,
+  data_stream: {},
   template: {
     settings: {},
     mappings: {

--- a/lib/collectContainers.ts
+++ b/lib/collectContainers.ts
@@ -3,7 +3,7 @@ import { getApmIndices, getLogsIndices, getMetricsIndices } from "../constants";
 import { SimpleAsset } from "../types";
 
 interface CollectContainers {
-  containers: SimpleAsset<'container'>[];
+  containers: SimpleAsset[];
 }
 
 export async function collectContainers({ esClient }: { esClient: Client }) {
@@ -53,15 +53,14 @@ export async function collectContainers({ esClient }: { esClient: Client }) {
     const podUid = fields['kubernetes.pod.uid'];
     const nodeName = fields['kubernetes.node.name'];
 
-    const parentEan = podUid ? `k8s.pod:${podUid}` : fields['host.hostname'];
+    const parentEan = podUid ? `pod:${podUid}` : `host:${fields['host.hostname']}`;
 
-    const container: SimpleAsset<'container'> = {
+    const container: SimpleAsset = {
       '@timestamp': new Date(),
-      'asset.type': 'container',
       'asset.kind': 'container',
       'asset.id': containerId,
       'asset.ean': `container:${containerId}`,
-      'asset.parents': parentEan && [parentEan],
+      'asset.parents': [parentEan],
     };
 
     acc.containers.push(container);

--- a/lib/collectContainers.ts
+++ b/lib/collectContainers.ts
@@ -36,7 +36,7 @@ export async function collectContainers({ esClient }: { esClient: Client }) {
             }
           }
         ],
-        must: [
+        should: [
           { exists: { field: 'kubernetes.container.id' } },
           { exists: { field: 'kubernetes.pod.uid' } },
           { exists: { field: 'host.hostname' } },
@@ -47,7 +47,6 @@ export async function collectContainers({ esClient }: { esClient: Client }) {
 
   const esResponse = await esClient.search(dsl);
 
-  // STEP TWO: Loop over collected pod documents and create a pod asset doc AND a node asset doc for each
   const docs = esResponse.hits.hits.reduce<CollectContainers>((acc, hit) => {
     const { fields = {} } = hit;
     const containerId = fields['container.id'];

--- a/lib/collectHosts.ts
+++ b/lib/collectHosts.ts
@@ -49,7 +49,6 @@ export async function collectHosts({ esClient }: { esClient: Client }): Promise<
 
   const esResponse = await esClient.search(dsl);
 
-  // STEP TWO: Loop over collected pod documents and create a pod asset doc AND a node asset doc for each
   const assets = esResponse.hits.hits.reduce<CollectHosts>((acc, hit) => {
     const { fields = {} } = hit;
     const hostName = fields['host.hostname'];
@@ -98,11 +97,3 @@ export async function collectHosts({ esClient }: { esClient: Client }): Promise<
 
   return assets.hosts;
 }
-
-function getHostType(fields: any): HostType {
-  if (fields['cloud.provider'] && fields['cloud.service.name']) {
-    return `${fields['cloud.provider']}.${fields['cloud.service.name']}`.toLowerCase() as HostType;
-  }
-
-  return 'host';
-};

--- a/lib/collectHosts.ts
+++ b/lib/collectHosts.ts
@@ -1,12 +1,12 @@
 import { Client } from "@elastic/elasticsearch";
 import { getApmIndices, getLogsIndices, getMetricsIndices } from "../constants";
-import { SimpleAsset, HostType } from "../types";
+import { SimpleAsset } from "../types";
 
 interface CollectHosts {
-  hosts: SimpleAsset<HostType>[];
+  hosts: SimpleAsset[];
 }
 
-export async function collectHosts({ esClient }: { esClient: Client }): Promise<SimpleAsset<HostType>[]> {
+export async function collectHosts({ esClient }: { esClient: Client }): Promise<SimpleAsset[]> {
   const dsl = {
     index: [getMetricsIndices(), getLogsIndices(), getApmIndices()],
     size: 1000,
@@ -55,11 +55,10 @@ export async function collectHosts({ esClient }: { esClient: Client }): Promise<
     const k8sNode = fields['kubernetes.node.name'];
     const k8sPod = fields['kubernetes.pod.uid'];
 
-    const hostEan = `${k8sNode ? 'k8s.node:' + k8sNode : 'host:' + hostName}`;
+    const hostEan = `host:${k8sNode || hostName}`;
 
-    const host: SimpleAsset<HostType> = {
+    const host: SimpleAsset = {
       '@timestamp': new Date(),
-      'asset.type': k8sNode ? 'k8s.node' : 'host',
       'asset.kind': 'host',
       'asset.id': k8sNode || hostName,
       'asset.name': k8sNode || hostName,
@@ -87,7 +86,7 @@ export async function collectHosts({ esClient }: { esClient: Client }): Promise<
     }
 
     if (k8sPod) {
-      host['asset.children'] = [`k8s.pod:${k8sPod}`];
+      host['asset.children'] = [`pod:${k8sPod}`];
     }
 
     acc.hosts.push(host);

--- a/lib/collectHostsFromMetrics.ts
+++ b/lib/collectHostsFromMetrics.ts
@@ -1,0 +1,101 @@
+import { Client } from "@elastic/elasticsearch";
+import { getMetricsIndices } from "../constants";
+import { SimpleAsset, HostType } from "../types";
+
+interface CollectHosts {
+  hosts: SimpleAsset<HostType>[];
+}
+
+export async function collectHosts({ esClient }: { esClient: Client }): Promise<SimpleAsset<HostType>[]> {
+  const dsl = {
+    index: [getMetricsIndices()],
+    size: 1000,
+    collapse: {
+      field: 'host.hostname'
+    },
+    sort: [
+      {
+        "@timestamp": "desc"
+      }
+    ],
+    _source: false,
+    fields: [
+      'kubernetes.*',
+      'cloud.*',
+      'orchestrator.cluster.name',
+      'host.hostname'
+    ],
+    query: {
+      bool: {
+        filter: [
+          {
+            range: {
+              '@timestamp': {
+                gte: 'now-1h'
+              }
+            }
+          }
+        ],
+        must: [
+          {
+            exists: {
+              field: 'host.hostname'
+            }
+          },
+        ]
+      }
+    }
+  };
+
+  console.log(JSON.stringify(dsl));
+  const esResponse = await esClient.search(dsl);
+
+  const assets = esResponse.hits.hits.reduce<CollectHosts>((acc, hit) => {
+    const { fields = {} } = hit;
+    const hostName = fields['host.hostname'];
+    const hostType: HostType = getHostType(fields);
+
+    const host: SimpleAsset<HostType> = {
+      '@timestamp': new Date(),
+      'asset.type': hostType,
+      'asset.kind': 'host',
+      'asset.id': hostName,
+      'asset.name': hostName,
+      'asset.ean': `${hostType}:${hostName}`,
+    };
+
+    if (fields['cloud.provider']) {
+      host['cloud.provider'] = fields['cloud.provider'];
+    }
+
+    if (fields['cloud.instance.id']) {
+      host['cloud.instance.id'] = fields['cloud.instance.id'];
+    }
+
+    if (fields['cloud.service.name']) {
+      host['cloud.service.name'] = fields['cloud.service.name'];
+    }
+
+    if (fields['cloud.region']) {
+      host['cloud.region'] = fields['cloud.region'];
+    }
+
+    if (fields['orchestrator.cluster.name']) {
+      host['orchestrator.cluster.name'] = fields['orchestrator.cluster.name'];
+    }
+
+    acc.hosts.push(host);
+
+    return acc;
+  }, { hosts: [] });
+
+  return assets.hosts;
+}
+
+function getHostType(fields: any): HostType {
+  if (fields['cloud.provider'] && fields['cloud.service.name']) {
+    return `${fields['cloud.provider']}.${fields['cloud.service.name']}`.toLowerCase() as HostType;
+  }
+
+  return 'host';
+};

--- a/lib/collectPods.ts
+++ b/lib/collectPods.ts
@@ -7,7 +7,6 @@ interface CollectPodsAndNodes {
 }
 
 export async function collectPods({ esClient }: { esClient: Client }) {
-  // STEP ONE: Query pods that reference their k8s nodes
   const dsl = {
     index: [getLogsIndices(), getApmIndices(), getMetricsIndices()],
     size: 1000,
@@ -15,7 +14,6 @@ export async function collectPods({ esClient }: { esClient: Client }) {
       field: 'kubernetes.pod.uid'
     },
     sort: [
-      { '_score': 'desc' },
       { '@timestamp': 'desc' }
     ],
     _source: false,
@@ -47,7 +45,6 @@ export async function collectPods({ esClient }: { esClient: Client }) {
 
   const esResponse = await esClient.search(dsl);
 
-  // STEP TWO: Loop over collected pod documents and create a pod asset doc AND a node asset doc for each
   const docs = esResponse.hits.hits.reduce<CollectPodsAndNodes>((acc, hit) => {
     const { fields = {} } = hit;
     const podUid = fields['kubernetes.pod.uid'];

--- a/lib/collectPods.ts
+++ b/lib/collectPods.ts
@@ -2,8 +2,8 @@ import { Client } from "@elastic/elasticsearch";
 import { getApmIndices, getLogsIndices, getMetricsIndices } from "../constants";
 import { SimpleAsset } from "../types";
 
-interface CollectPodsAndNodes {
-  pods: SimpleAsset<'k8s.pod'>[];
+interface CollectPods {
+  pods: SimpleAsset[];
 }
 
 export async function collectPods({ esClient }: { esClient: Client }) {
@@ -45,19 +45,18 @@ export async function collectPods({ esClient }: { esClient: Client }) {
 
   const esResponse = await esClient.search(dsl);
 
-  const docs = esResponse.hits.hits.reduce<CollectPodsAndNodes>((acc, hit) => {
+  const docs = esResponse.hits.hits.reduce<CollectPods>((acc, hit) => {
     const { fields = {} } = hit;
     const podUid = fields['kubernetes.pod.uid'];
     const nodeName = fields['kubernetes.node.name'];
     const clusterName = fields['orchestrator.cluster.name'];
 
-    const pod: SimpleAsset<'k8s.pod'> = {
+    const pod: SimpleAsset = {
       '@timestamp': new Date(),
-      'asset.type': 'k8s.pod',
       'asset.kind': 'pod',
       'asset.id': podUid,
-      'asset.ean': `k8s.pod:${podUid}`,
-      'asset.parents': [`k8s.node:${nodeName}`]
+      'asset.ean': `pod:${podUid}`,
+      'asset.parents': [`host:${nodeName}`]
     };
 
     if (fields['cloud.provider']) {

--- a/lib/collectServices.ts
+++ b/lib/collectServices.ts
@@ -8,15 +8,9 @@ interface CollectServices {
 
 const MISSING_KEY = "__unknown__";
 
-/**
- * service.name|service.environment
- * -> containers|hostname
- */
-
 export async function collectServices({ esClient }: { esClient: Client }): Promise<SimpleAsset<'service' | 'container'>[]> {
-  // STEP ONE: Query pods that reference their k8s nodes
   const dsl = {
-    index: [getApmIndices(), getLogsIndices(), getMetricsIndices()].concat(','),
+    index: getApmIndices(),
     "size": 0,
     "sort": [
       {

--- a/lib/collectServices.ts
+++ b/lib/collectServices.ts
@@ -3,12 +3,12 @@ import { getApmIndices, getLogsIndices, getMetricsIndices } from "../constants";
 import { SimpleAsset } from "../types";
 
 interface CollectServices {
-  services: SimpleAsset<'service'>[];
+  services: SimpleAsset[];
 }
 
 const MISSING_KEY = "__unknown__";
 
-export async function collectServices({ esClient }: { esClient: Client }): Promise<SimpleAsset<'service' | 'container'>[]> {
+export async function collectServices({ esClient }: { esClient: Client }): Promise<SimpleAsset[]> {
   const dsl = {
     index: getApmIndices(),
     "size": 0,
@@ -75,9 +75,8 @@ export async function collectServices({ esClient }: { esClient: Client }): Promi
     const [serviceName, environment] = hit.key;
     const containerHosts = hit.container_host.buckets;
 
-    const service: SimpleAsset<'service'> = {
+    const service: SimpleAsset = {
       '@timestamp': new Date(),
-      'asset.type': 'service',
       'asset.kind': 'service',
       'asset.id': serviceName,
       'asset.ean': `service:${serviceName}`,

--- a/lib/es_client.ts
+++ b/lib/es_client.ts
@@ -36,12 +36,6 @@ export async function getEsClient(options: AssetClientOptions) {
     return singletonClient;
   }
 
-  if (!process.env.ES_USERNAME || !process.env.ES_PASSWORD) {
-    throw new Error('Please provide username and password for Elasticsearch via ES_USERNAME and ES_PASSWORD env vars');
-  }
-
-  const tlsRejectUnauthorized = (process.env.ASSETS_READ_ES_TLS_REJECT_UNAUTHORIZED === "false") ? false : true;
-
   singletonClient = new AssetClient(options);
   // await template creation?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "elastic-assets-etl",
+  "name": "elastic-asset-etl-poc",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/run.ts
+++ b/run.ts
@@ -1,11 +1,11 @@
 import yargs from "yargs/yargs";
-import { collectHosts } from "./lib/collectHostsFromMetrics";
+import { collectHosts } from "./lib/collectHosts";
 import { collectServices } from "./lib/collectServices";
+import { collectPods } from "./lib/collectPods";
+import { collectContainers } from "./lib/collectContainers";
 import { AssetClient, getEsClient } from "./lib/es_client";
 import { HostType, SimpleAsset } from "./types";
 import config from "./config/config.json";
-import { collectPods } from "./lib/collectPods";
-import { collectContainers } from "./lib/collectContainers";
 
 main();
 

--- a/run.ts
+++ b/run.ts
@@ -4,14 +4,14 @@ import { collectServices } from "./lib/collectServices";
 import { collectPods } from "./lib/collectPods";
 import { collectContainers } from "./lib/collectContainers";
 import { AssetClient, getEsClient } from "./lib/es_client";
-import { HostType, SimpleAsset } from "./types";
+import { SimpleAsset } from "./types";
 import config from "./config/config.json";
 
 main();
 
-const assetToBulkOperation = (asset: SimpleAsset<HostType | 'service' | 'container' | 'k8s.pod'>) => {
+const assetToBulkOperation = (asset: SimpleAsset) => {
   return [
-    { create: { _index: `assets-${asset['asset.type']}-default` } },
+    { create: { _index: `assets-${asset['asset.kind']}-default` } },
     asset,
   ];
 };

--- a/types.ts
+++ b/types.ts
@@ -1,7 +1,6 @@
-export interface SimpleAsset<T> {
+export interface SimpleAsset {
   '@timestamp': Date;
   'asset.ean': string;
-  'asset.type': T;
   'asset.id': string;
   'asset.kind': string;
   'asset.name'?: string;
@@ -17,4 +16,3 @@ export interface SimpleAsset<T> {
   'kubernetes.node.hostname'?: string;
 }
 
-export type HostType = 'host' | 'aws.ec2' | 'k8s.node' | 'gcp.gce';

--- a/types.ts
+++ b/types.ts
@@ -3,11 +3,17 @@ export interface SimpleAsset<T> {
   'asset.ean': string;
   'asset.type': T;
   'asset.id': string;
+  'asset.kind': string;
   'asset.name'?: string;
   'asset.parents'?: string[];
   'asset.children'?: string[];
   'asset.references'?: string[];
   'cloud.provider'?: string;
+  'cloud.service.name'?: string;
+  'cloud.region'?: string;
+  'cloud.instance.id'?: string;
   'orchestrator.cluster.name'?: string;
   'service.environment'?: string;
 }
+
+export type HostType = 'host' | 'aws.ec2' | 'k8s.node' | 'gcp.gce';

--- a/types.ts
+++ b/types.ts
@@ -14,6 +14,7 @@ export interface SimpleAsset<T> {
   'cloud.instance.id'?: string;
   'orchestrator.cluster.name'?: string;
   'service.environment'?: string;
+  'kubernetes.node.hostname'?: string;
 }
 
 export type HostType = 'host' | 'aws.ec2' | 'k8s.node' | 'gcp.gce';


### PR DESCRIPTION
### Summary
Closes https://github.com/elastic/kibana/issues/155870

The change introduces asset-scoped queries for hosts, pods, containers and services. Each query is responsible for building documents of a single type and setting relationships found in the documents metadata. The queries are only building assets of the concerned type and not the related ones; for example if host document contains pod metadata, the host logic will set the pod ean as a child, but leave the pod asset creation to the pod logic. This may create dangling references but keeps the post processing of each query simple, and can be updated later if needed.

### Testing
- setup clusters in `config.json` (I used edge-oblt as source and local es as dest)
- run `npx ts-node run.ts --read=<source> --write=<dest>`
- 4 types of assets should be inserted in `assets-*` data streams
- one can use assets-manager API to get results of random assets (eg `GET kbn:/api/asset-manager/assets/related?relation=ancestors&from=2023-05-05T00:00:00.000Z&ean=service:emailService&maxDistance=3`)